### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/dataCatalog.R
+++ b/dataCatalog.R
@@ -5,7 +5,7 @@ library(shiny)
 library(shinyjs)
 
 createLink <- function(val) {
-  sprintf('<a href="https://dx.doi.org/%s" target="_blank">DATA</a>', val)
+  sprintf('<a href="https://doi.org/%s" target="_blank">DATA</a>', val)
   # sprintf('<a href="https://www.google.com/#q=%s" target="_blank" class="btn btn-primary">Info</a>',val)
 }
 

--- a/resultset2catalog.xsl
+++ b/resultset2catalog.xsl
@@ -11,7 +11,7 @@
         <xsl:for-each select="document">
             <xsl:element name="document">
                 <tr><td><xsl:element name="a">
-                    <xsl:attribute name="href">https://dx.doi.org/<xsl:value-of select='substring(./doi,5)'/></xsl:attribute>
+                    <xsl:attribute name="href">https://doi.org/<xsl:value-of select='substring(./doi,5)'/></xsl:attribute>
                     <xsl:value-of select="./packageid"/>
                 </xsl:element>  
                     </td>


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating the two functions that generate new DOI-URLs.

Cheers :-)